### PR TITLE
Adição da ATA do dia 26/03

### DIFF
--- a/docs/atas-reuniao/ata-reuniao-1.md
+++ b/docs/atas-reuniao/ata-reuniao-1.md
@@ -1,12 +1,12 @@
-# Ata de Reunião 
+# Ata de Reunião 01
 
-**Data:** 31/03/2025  
+**Data:** 26/03/2025  
 
-**Hora Prevista:** 16:00 até 18:00
+**Hora Prevista:** 14:00 - 16:00  
+**Hora Realizada:** 14:00 - 16:00   
+**Local:** Presencial 
 
-**Hora Realizada:** 16:00 até 17:02
-
-**Local:** Presencial
+**Redator:** [Kaleb Macedo](https://github.com/kalebmacedo)
 
 ---
 
@@ -14,38 +14,49 @@
 
 <font size="3"><p style="text-align: left">Tabela 1: Presença</p></font>
 
+| Nome              | Presença |
+|-------------------|----------|
+| Felipe das Neves  | ✔️        |
+| Breno Alexandre   | ✔️        |
+| Julio Cesar       | ✔️        |
+| Lucas Soares      | ✔️        |
+| Kaleb de Macedo   | ✔️        |
+| Othávio Araujo    | ✔️        |
 
-| Nome            | Presença |
-|-----------------|----------|
-| Felipe das Neves  | ✔️    |
-| Breno Alexandre   | ✔️    |
-| Julio Cesar       | ✔️    |
-| Lucas Soares      | ✔️    |
-| Kaleb de Souza    | ✔️    |
-| Othavio Araujo    | ✔️    |
-
-<font size="3"><p style="text-align: left">Fonte: Autores</p></font>
+<font size="3"><p style="text-align: left">Fonte: [Kaleb Macedo](https://github.com/kalebmacedo), 2025.</p></font>
 
 ---
+
 ## Discussões
 
-- ....
-
-
+- Estrutura de projeto para o compilador foi definida:
+  - Pasta para analisador léxico (`lex` ou `lexer`)
+  - Pasta para analisador sintático (`parser`)
+  - Pasta para testes
+  - Pasta para artefatos compilados (`build` ou `bin`)
+- Implementado controle de versão com uso de `Git`, com repositórios no GitHub/GitLab e uso de convenções de `commit` e `branching`.
+- Realização de primeiros testes com `flex` + `bison`:
+  - Analisador léxico mínimo que identifica tokens como `Hello` e `World`
+  - Integração com o parser e geração de saída para confirmação
+  - Verificação de compilação e execução
+  - Análise dos arquivos `hello.l` e `hello.y`
 
 ---
+
 ### Decisões:
-- ....
 
+- O teste com `hello.l` e `hello.y` é obrigatório para todos os integrantes do grupo.
+- Possivelmente será criado um Interpretador.
 
 ---
+
 ### Próxima Reunião
-**02/04/2025 às 22h**
+**02/04/2025 às 14h**
 
 ---
 
 # Tabela de Versionamento 
 
-| Versão | Data | Descrição da Alteração | Nome(s) Integrante(s) |
-| :----: | :--: | :--------------------: | :-------------------: |
-| 1.0 | 06/02/2025 | .. | .. |
+| Versão | Data       | Descrição da Alteração      | Nome(s) Integrante(s) |
+| :----: | :--------: | :-------------------------: | :-------------------: |
+| 1.0    | 24/04/2025 | Criação da ata da reunião 01   | [Kaleb Macedo](https://github.com/kalebmacedo)       |


### PR DESCRIPTION
# 📄 Criação da ATA 01 – Reunião de Compiladores

## ✍️ Descrição
Este pull request adiciona o arquivo da **ATA 01** referente à reunião realizada no dia **31/03/2025**, com as seguintes informações:
- Participantes presentes
- Discussões sobre estrutura do projeto, controle de versão e testes iniciais com `flex` + `bison`
- Decisões relacionadas à padronização da estrutura e obrigatoriedade dos testes
- Registro da próxima reunião e controle de versionamento

## 📁 Arquivo adicionado
- `docs/atas/ata01.md`

## ✅ Checklist
- [x] Participantes listados
- [x] Discussões documentadas
- [x] Decisões anotadas
- [x] Próxima reunião definida
- [x] Tabela de versionamento criada

## 🧠 Observações
Reunião com base em conteúdos práticos apresentados em sala (estrutura de projeto, primeiros testes e PBL). Arquivo pronto para revisão e merge no repositório principal.
